### PR TITLE
Prevent user from selecting an invalid execution point

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject vvvvalvalval/scope-capture-nrepl "0.2.0"
+(defproject vvvvalvalval/scope-capture-nrepl "0.3.0-SNAPSHOT"
   :description "nREPL middleware for scope-capture"
   :url "https://github.com/vvvvalvalval/scope-capture-nrepl"
   :license {:name "MIT"

--- a/src/sc/nrepl/repl.clj
+++ b/src/sc/nrepl/repl.clj
@@ -1,16 +1,18 @@
 (ns sc.nrepl.repl
-  (:require [sc.nrepl.impl :as i]))
+  (:require [sc.nrepl.impl :as i]
+            [sc.impl.db :refer [db]]))
 
 (defn in-ep
   "'In Execution Point' - Sets the current Execution Point Id to `ep-id`.
   Subsequent commands sent to the REPL via 'eval' or 'load-file'
   will be transformed so that each form `expr` is wrapped with (sc.api/letsc epid expr)"
   [ep-id]
-  (reset! i/current-ep-id ep-id)
+  (when (or (nil? ep-id)
+            (sc.impl/find-ep @db ep-id))
+    (reset! i/current-ep-id ep-id))
   nil)
 
 (defn exit
   "Exists the context of the current Execution Point, if any. Idempotent."
   []
   (in-ep nil))
-


### PR DESCRIPTION
Resolves issue #1. 

Note both this PR and #5 are independent of each other aside from sharing the version bump commit 2a710c8.